### PR TITLE
Added support for Rackspace Cloud Files as a transport

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,8 @@ group :tester do
 
   # transports
   gem 'aws-sdk', '~> 2.2', '>= 2.2.12'
+  gem 'mime-types', '<= 2.99.1' # required by fog
+  gem 'fog', '~> 1.38', '>= 1.22.0'
 end
 
 group :ui do

--- a/README.mdown
+++ b/README.mdown
@@ -18,6 +18,8 @@ So you're backing up your databases, but are you regularly checking that the bac
      - [Generic Transport Parameters](#generic-transport-parameters)
      - [S3 (type: `s3`)](#s3-type-s3)
        - [S3 Transport Example](#s3-transport-example)
+     - [Rackspace Cloud Files (type: `rscf`)](#rackspace-cloud-files-type-rscf)
+       - [Rackspace Cloud Files Transport Example](#rackspace-cloud-files-transport-example)
      - [Local File (type: `local`)](#local-file-type-local)
        - [Local File Example](#local-file-example)
    - [Engines](#engines)
@@ -161,6 +163,7 @@ See the sections below for how to configure Engines, Transports and Tests.
 Transports are how you retrieve the backup file itself. They are also responsible for decompressing the file, the code supports nested compression (compressed files within compressed files). Currently implemented transports are...
 
 * S3
+* Rackspace Cloud Files
 * Local file
 
 Custom transports can also be loaded at runtime if they are placed in `/etc/uphold/transports`. If you need extra rubygems installed you will need to create a new Dockerfile with the base set to `uphold-tester` and then override the Gemfile and re-bundle. Then adjust your `uphold.yml` to use your new container.
@@ -217,6 +220,36 @@ As the `path` is sent to the S3 API as a prefix, it will match all folders, the 
         date_format: '%Y.%m.%d'
         date_offset: 0
         folder_within: mongodb/databases/MongoDB
+
+##### Rackspace Cloud Files (type: `rscf`)
+
+The Rackspace Cloud Files transport allows you to pull your backup files from a container in Cloud Files. It has it's own extra settings:
+
+* `region`
+  * The region that your Cloud Files container resides in (eg. `ord`)
+* `username`
+  * The username of a user with privileges to read from Cloud Files
+* `api_key`
+  * The API key for `username`
+* `container`
+  * The name of the container to load in Cloud Files
+
+If your backup is in the root of `container`, specify a blank string for the `path` setting.
+
+    path: ''
+
+###### Rackspace Cloud Files Transport Example
+
+    transport:
+      type: rscf
+      settings:
+        region: iad
+        username: your-rackspace-username
+        api_key: your-rackspace-username-api-key
+        container: backups
+        path: mysql/website1
+        filename: MySQL.sql.gz
+        folder_within: ./
 
 ##### Local File (type: `local`)
 

--- a/lib/transports/rscf.rb
+++ b/lib/transports/rscf.rb
@@ -1,0 +1,39 @@
+module Uphold
+  module Transports
+    class Rscf < Transport
+      def initialize(params)
+        super(params)
+        @region = params[:region]
+        @username = params[:username]
+        @api_key = params[:api_key]
+      end
+
+      def fetch_backup
+        logger.debug "Connecting to Rackspace Cloud Files region #{@region} as '#{@username}'."
+        rscf = Fog::Storage.new({
+            :provider            => 'Rackspace',
+            :rackspace_username  => @username,
+            :rackspace_api_key   => @api_key,
+            :rackspace_region    => @region,
+            :connection_options  => {
+                # Rackspace's endpoint has a Thawte Premium Server CA which was removed from
+                # Debian's ca-certificates package, causing verify to fail if enabled.
+                :ssl_verify_peer => false
+            }
+        })
+        logger.debug "Loading container '#{@path}'."
+        container = rscf.directories.new :key => @path
+
+        File.open(File.join(@tmpdir, File.basename(@filename)), 'wb') do |file|
+          logger.info "Downloading '#{@filename}' from Rackspace Cloud Files container '#{@path}'."
+          container.files.get(@filename) do | data, remaining, content_length |
+            file.syswrite data
+          end
+          decompress(file) do |_b|
+          end
+        end
+        File.join(@tmpdir, @folder_within)
+      end
+    end
+  end
+end

--- a/lib/transports/rscf.rb
+++ b/lib/transports/rscf.rb
@@ -6,6 +6,7 @@ module Uphold
         @region = params[:region]
         @username = params[:username]
         @api_key = params[:api_key]
+        @container = params[:container]
       end
 
       def fetch_backup
@@ -21,11 +22,14 @@ module Uphold
                 :ssl_verify_peer => false
             }
         })
-        logger.debug "Loading container '#{@path}'."
-        container = rscf.directories.new :key => @path
+        logger.debug "Loading container '#{@container}'."
+        container = rscf.directories.new :key => @container
 
         File.open(File.join(@tmpdir, File.basename(@filename)), 'wb') do |file|
-          logger.info "Downloading '#{@filename}' from Rackspace Cloud Files container '#{@path}'."
+          unless @path.blank?
+            @filename = "#{@path}/#{@filename}"
+          end
+          logger.info "Downloading '#{@filename}' from Rackspace Cloud Files container '#{@container}'."
           container.files.get(@filename) do | data, remaining, content_length |
             file.syswrite data
           end


### PR DESCRIPTION
Rackspace's official Ruby SDK is the [fog](http://fog.io/) library which also supports S3, local and Google Storage. If you want to merge this PR it may be worth using fog for other transports as well.

Aside - I also had to add a `mime-types` dependency to `Gemfile` because `grit` was locking an older version that did not work with `fog`. I'm not sure if this is best practice or just down right wrong but it was the only way I could get `fog` to work. Let me know if this should be done differently.
