### PR TITLE
Updates to work with latest docker version and minor fixes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ group :tester do
 
   # engines
   gem 'pg',        '~> 0.18.4'
-  gem 'mysql2',    '~> 0.4.2'
+  gem 'mysql2',    '~> 0.4.6'
   gem 'mongoid',   '~> 5.0', '>= 5.0.2'
   gem 'rethinkdb', '~> 2.2', '>= 2.2.0.2'
   gem 'sqlite3',   '~> 1.3', '>= 1.3.11'

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'sequel',     '~> 4.30'
-gem 'docker-api', '~> 1.25'
+gem 'docker-api', '~> 1.33.2'
 
 group :tester do
   # core

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,11 +21,11 @@ GEM
     colored (1.2)
     daemons (1.2.3)
     diff-lcs (1.2.5)
-    docker-api (1.25.0)
-      excon (>= 0.38.0)
+    docker-api (1.33.2)
+      excon (>= 0.55.0)
       json
     eventmachine (1.0.9.1)
-    excon (0.45.4)
+    excon (0.55.0)
     git-up (0.5.12)
       colored (>= 1.2)
       grit

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,7 +22,7 @@ GEM
     daemons (1.2.3)
     diff-lcs (1.2.5)
     docker-api (1.33.2)
-      excon (>= 0.55.0)
+      excon (>= 0.38.0)
       json
     eventmachine (1.0.9.1)
     excon (0.55.0)

--- a/lib/engines/mysql.rb
+++ b/lib/engines/mysql.rb
@@ -8,7 +8,7 @@ module Uphold
         @docker_tag ||= '5.7.10'
         @docker_env ||= ['MYSQL_ALLOW_EMPTY_PASSWORD=yes', "MYSQL_DATABASE=#{@database}"]
         @port ||= 3306
-        @sql_file ||= 'MySQL.sql'
+        @sql_file = params[:sql_file] || 'MySQL.sql'
       end
 
       def load_backup(path)

--- a/lib/engines/postgresql.rb
+++ b/lib/engines/postgresql.rb
@@ -8,7 +8,7 @@ module Uphold
         @docker_tag ||= '9.5.0'
         @docker_env ||= ["POSTGRES_USER=#{@database}", "POSTGRES_DB=#{@database}"]
         @port ||= 5432
-        @sql_file ||= 'PostgreSQL.sql'
+        @sql_file = params[:sql_file] ||  'PostgreSQL.sql'
       end
 
       def load_backup(path)


### PR DESCRIPTION
updated the docker-api  and excon gem versions to work with the latest docker version and prevent 400 errors while calling the docker api.

Changed the definition of sql_file parameter on mysql and pgssql engines, since is not respecting the params values.